### PR TITLE
loading speed - reduce gene, transcript page data bundles

### DIFF
--- a/exac.py
+++ b/exac.py
@@ -758,12 +758,11 @@ def variant_api(variant_str):
         print 'Failed on variant:', variant_str, ';Error=', traceback.format_exc()
         abort(404)
 
-def get_gene_data(db, gene_id, gene,request_type, cache_key):
+def get_gene_data(db, gene_id, gene, request_type, cache_key):
     try:
-
         transcript_id = gene['canonical_transcript']
         transcripts_in_gene = lookups.get_transcripts_in_gene(db, gene_id)
-        variant_data  = lookups.get_variants_in_transcript(db, transcript_id)
+        variant_data  = lookups.get_variants_in_gene_or_transcript(db, gene_id=gene_id)
         variants_in_transcript = variant_data["all_variants"]
 
         # Get some canonical transcript and corresponding info
@@ -838,7 +837,8 @@ def get_transcript_data(db, transcript_id, transcript, request_type, cache_key):
     try:
         gene = lookups.get_gene(db, transcript['gene_id'])
         gene['transcripts'] = lookups.get_transcripts_in_gene(db, transcript['gene_id'])
-        variants_in_transcript = lookups.get_variants_in_transcript(db, transcript_id)
+        variant_data = lookups.get_variants_in_gene_or_transcript(db, transcript_id=transcript_id)
+        variants_in_transcript = variant_data['all_variants']
         coverage_stats_exomes = lookups.get_coverage_for_transcript(db, 'exome_coverage', transcript['xstart'] - EXON_PADDING, transcript['xstop'] + EXON_PADDING)
         # change base_coverage to e.g. genome_base_coverage when the data gets here
         coverage_stats_genomes = lookups.get_coverage_for_transcript(db, 'genome_coverage', transcript['xstart'] - EXON_PADDING, transcript['xstop'] + EXON_PADDING)

--- a/exac.py
+++ b/exac.py
@@ -59,10 +59,10 @@ app.config.update(dict(
     DB_NAME='exac',
     DEBUG=True,
     SECRET_KEY='development key',
-    LOAD_DB_PARALLEL_PROCESSES = int(os.getenv('LOAD_DB_PARALLEL_PROCESSES_NUMB', 4)),
+    LOAD_DB_PARALLEL_PROCESSES = int(os.getenv('LOAD_DB_PARALLEL_PROCESSES_NUMB', 3)),
     # contigs assigned to threads, so good to make this a factor of 24 (eg. 2,3,4,6,8)
-    EXOMES_SITES_VCFS=glob.glob(os.path.join(os.path.dirname(__file__), EXOME_FILES_DIRECTORY, '*.vcf.gz')),
-    GENOMES_SITES_VCFS=glob.glob(os.path.join(os.path.dirname(__file__), GENOME_FILES_DIRECTORY, '*.vcf.gz')),
+    EXOMES_SITES_VCFS=glob.glob(os.path.join(os.path.dirname(__file__), EXOME_FILES_DIRECTORY, 'x/part-000*.bgz')),
+    GENOMES_SITES_VCFS=glob.glob(os.path.join(os.path.dirname(__file__), GENOME_FILES_DIRECTORY, 'x/part-000*.bgz')),
     GENCODE_GTF=os.path.join(os.path.dirname(__file__), SHARED_FILES_DIRECTORY, 'gencode.gtf.gz'),
     CANONICAL_TRANSCRIPT_FILE=os.path.join(os.path.dirname(__file__), SHARED_FILES_DIRECTORY, 'canonical_transcripts.txt.gz'),
     OMIM_FILE=os.path.join(os.path.dirname(__file__), SHARED_FILES_DIRECTORY, 'omim_info.txt.gz'),
@@ -163,17 +163,19 @@ def load_base_coverage_genomes():
     coverage_files = app.config['GENOME_BASE_COVERAGE_FILES']
     return load_individual_coverage_files(coverage_files, 'genome_coverage')
 
+def load_variants_in_file_using_tabix(sites_file, i, n, db_collection):
+    variants_generator = parse_tabix_file_subset([sites_file], i, n, get_variants_from_sites_vcf)
+    try:
+        db_collection.insert(variants_generator, w=0)
+    except pymongo.errors.InvalidOperation:
+        pass  # handle error when variant_generator is empty
+
 def load_variants_file():
-    def load_variants(sites_file, i, n, db):
-        variants_generator = parse_tabix_file_subset([sites_file], i, n, get_variants_from_sites_vcf)
-        try:
-            db.variants.insert(variants_generator, w=0)
-        except pymongo.errors.InvalidOperation:
-            pass  # handle error when variant_generator is empty
+
 
     db = get_db()
-    db.variants.drop()
-    print("Dropped db.variants")
+    #db.variants.drop()
+    #print("Dropped db.variants")
 
     # grab variants from sites VCF
     db.variants.ensure_index('xpos')
@@ -186,31 +188,37 @@ def load_variants_file():
     sites_vcfs = app.config['EXOMES_SITES_VCFS']
     if len(sites_vcfs) == 0:
         raise IOError("No vcf file found")
-    elif len(sites_vcfs) > 1:
-        raise Exception("More than one sites vcf file found: %s" % sites_vcfs)
+    #elif len(sites_vcfs) > 1:
+    #    raise Exception("More than one sites vcf file found: %s" % sites_vcfs)
 
     procs = []
     num_procs = app.config['LOAD_DB_PARALLEL_PROCESSES']
-    for i in range(num_procs):
-        p = Process(target=load_variants, args=(sites_vcfs[0], i, num_procs, db))
+    for sites_vcf in sites_vcfs:
+        p = Process(target=load_all_variants_in_file, args=(sites_vcf, db.variants)) #target=load_variants_in_file_using_tabix, args=(sites_vcf, i, num_procs, db.variants))
         p.start()
         procs.append(p)
+        if len(procs) > num_procs:
+            print("Waiting for: " + str(p))
+            procs[0].join()
+            del procs[0]
+            print("Done waiting for: " + str(p))
     return procs
 
     #print 'Done loading variants. Took %s seconds' % int(time.time() - start_time)
 
+def load_all_variants_in_file(sites_file, db_collection):
+    with gzip.open(sites_file) as f:
+        variants_generator = get_variants_from_sites_vcf(f)
+        try:
+            db_collection.insert(variants_generator, w=0)
+        except pymongo.errors.InvalidOperation:
+            pass  # handle error when variant_generator is empty
+
 def load_gnomad_vcf():
-    def load_all_variants_in_file(sites_file, db):
-        with gzip.open(sites_file) as f:
-            variants_generator = get_variants_from_sites_vcf(f)
-            try:
-                db.gnomadVariants2.insert(variants_generator, w=0)
-            except pymongo.errors.InvalidOperation:
-                pass  # handle error when variant_generator is empty
 
     db = get_db()
-    db.gnomadVariants2.drop()
-    print("Dropped db.gnomadVariants2")
+    #db.gnomadVariants2.drop()
+    #print("Dropped db.gnomadVariants2")
 
     # grab variants from sites VCF
     db.gnomadVariants2.ensure_index('xpos')
@@ -229,7 +237,7 @@ def load_gnomad_vcf():
     procs = []
     num_procs = app.config['LOAD_DB_PARALLEL_PROCESSES']
     for sites_vcf in sites_vcfs:
-        p = Process(target=load_all_variants_in_file, args=(sites_vcf, db))
+        p = Process(target=load_all_variants_in_file, args=(sites_vcf, db.gnomadVariants2))
         p.start()
         procs.append(p)
         if len(procs) > num_procs:
@@ -709,9 +717,6 @@ def variant_page(variant_str):
     try:
         exac = variant_data(variant_str, 'exac')
         gnomad = variant_data(variant_str, 'gnomad')
-        #from pprint import pformat
-        #print("exac" + pformat(exac))
-        #print("gnomad" + pformat(gnomad))
         print 'Rendering variant: %s' % variant_str
         return render_template(
             'variant.html',
@@ -762,9 +767,6 @@ def get_gene_data(db, gene_id, gene,request_type, cache_key):
         # Get some canonical transcript and corresponding info
         transcript_id = gene['canonical_transcript']
         transcript = lookups.get_transcript(db, transcript_id)
-        variants_in_transcript = lookups.get_variants_in_transcript(db, transcript_id)
-        cnvs_in_transcript = lookups.get_exons_cnvs(db, transcript_id)
-        cnvs_per_gene = lookups.get_cnvs(db, gene_id)
         coverage_stats_exomes = lookups.get_coverage_for_transcript(db, 'exome_coverage', transcript['xstart'] - EXON_PADDING, transcript['xstop'] + EXON_PADDING)
         # change base_coverage to e.g. genome_base_coverage when the data gets here
         coverage_stats_genomes = lookups.get_coverage_for_transcript(db, 'genome_coverage', transcript['xstart'] - EXON_PADDING, transcript['xstop'] + EXON_PADDING)
@@ -772,7 +774,7 @@ def get_gene_data(db, gene_id, gene,request_type, cache_key):
             'exomes': coverage_stats_exomes,
             'genomes': coverage_stats_genomes
         }
-        add_transcript_coordinate_to_variants(db, variants_in_transcript, transcript_id)
+        add_transcript_coordinate_to_variants(db, variants_in_gene, transcript_id)
         constraint_info = lookups.get_constraint_for_transcript(db, transcript_id)
         if request_type == 'template':
             result = render_template(
@@ -780,11 +782,8 @@ def get_gene_data(db, gene_id, gene,request_type, cache_key):
                 gene=gene,
                 transcript=transcript,
                 variants_in_gene=variants_in_gene,
-                variants_in_transcript=variants_in_transcript,
                 transcripts_in_gene=transcripts_in_gene,
                 coverage_stats=coverage_stats,
-                cnvs = cnvs_in_transcript,
-                cnvgenes = cnvs_per_gene,
                 constraint=constraint_info,
                 uuid_lists=variant_data['uuid_lists']
             )
@@ -793,11 +792,8 @@ def get_gene_data(db, gene_id, gene,request_type, cache_key):
                 gene=gene,
                 transcript=transcript,
                 variants_in_gene=variants_in_gene,
-                variants_in_transcript=variants_in_transcript,
                 transcripts_in_gene=transcripts_in_gene,
                 coverage_stats=coverage_stats,
-                cnvs = cnvs_in_transcript,
-                cnvgenes = cnvs_per_gene,
                 constraint=constraint_info,
                 uuid_lists=variant_data['uuid_lists']
             )
@@ -842,8 +838,6 @@ def get_transcript_data(db, transcript_id, transcript, request_type, cache_key):
         gene = lookups.get_gene(db, transcript['gene_id'])
         gene['transcripts'] = lookups.get_transcripts_in_gene(db, transcript['gene_id'])
         variants_in_transcript = lookups.get_variants_in_transcript(db, transcript_id)
-        cnvs_in_transcript = lookups.get_exons_cnvs(db, transcript_id)
-        cnvs_per_gene = lookups.get_cnvs(db, transcript['gene_id'])
         coverage_stats_exomes = lookups.get_coverage_for_transcript(db, 'exome_coverage', transcript['xstart'] - EXON_PADDING, transcript['xstop'] + EXON_PADDING)
         # change base_coverage to e.g. genome_base_coverage when the data gets here
         coverage_stats_genomes = lookups.get_coverage_for_transcript(db, 'genome_coverage', transcript['xstart'] - EXON_PADDING, transcript['xstop'] + EXON_PADDING)
@@ -856,32 +850,16 @@ def get_transcript_data(db, transcript_id, transcript, request_type, cache_key):
             result = render_template(
                 'transcript.html',
                 transcript=transcript,
-                transcript_json=json.dumps(transcript),
                 variants_in_transcript=variants_in_transcript,
-                variants_in_transcript_json=json.dumps(variants_in_transcript),
                 coverage_stats=coverage_stats,
-                coverage_stats_json=json.dumps(coverage_stats),
                 gene=gene,
-                gene_json=json.dumps(gene),
-                cnvs = cnvs_in_transcript,
-                cnvs_json=json.dumps(cnvs_in_transcript),
-                cnvgenes = cnvs_per_gene,
-                cnvgenes_json=json.dumps(cnvs_per_gene)
             )
         if request_type == 'json':
             result = jsonify(
                 transcript=transcript,
-                transcript_json=json.dumps(transcript),
                 variants_in_transcript=variants_in_transcript,
-                variants_in_transcript_json=json.dumps(variants_in_transcript),
                 coverage_stats=coverage_stats,
-                coverage_stats_json=json.dumps(coverage_stats),
                 gene=gene,
-                gene_json=json.dumps(gene),
-                cnvs = cnvs_in_transcript,
-                cnvs_json=json.dumps(cnvs_in_transcript),
-                cnvgenes = cnvs_per_gene,
-                cnvgenes_json=json.dumps(cnvs_per_gene)
             )
         cache.set(cache_key, result, timeout=1000*60)
         return result

--- a/exac.py
+++ b/exac.py
@@ -760,12 +760,13 @@ def variant_api(variant_str):
 
 def get_gene_data(db, gene_id, gene,request_type, cache_key):
     try:
-        variant_data = lookups.get_variants_in_gene(db, gene_id)
-        variants_in_gene = variant_data['all_variants']
+
+        transcript_id = gene['canonical_transcript']
         transcripts_in_gene = lookups.get_transcripts_in_gene(db, gene_id)
+        variant_data  = lookups.get_variants_in_transcript(db, transcript_id)
+        variants_in_transcript = variant_data["all_variants"]
 
         # Get some canonical transcript and corresponding info
-        transcript_id = gene['canonical_transcript']
         transcript = lookups.get_transcript(db, transcript_id)
         coverage_stats_exomes = lookups.get_coverage_for_transcript(db, 'exome_coverage', transcript['xstart'] - EXON_PADDING, transcript['xstop'] + EXON_PADDING)
         # change base_coverage to e.g. genome_base_coverage when the data gets here
@@ -774,14 +775,14 @@ def get_gene_data(db, gene_id, gene,request_type, cache_key):
             'exomes': coverage_stats_exomes,
             'genomes': coverage_stats_genomes
         }
-        add_transcript_coordinate_to_variants(db, variants_in_gene, transcript_id)
+        add_transcript_coordinate_to_variants(db, variants_in_transcript, transcript_id)
         constraint_info = lookups.get_constraint_for_transcript(db, transcript_id)
         if request_type == 'template':
             result = render_template(
                 'gene.html',
                 gene=gene,
                 transcript=transcript,
-                variants_in_gene=variants_in_gene,
+                variants_in_transcript=variants_in_transcript,
                 transcripts_in_gene=transcripts_in_gene,
                 coverage_stats=coverage_stats,
                 constraint=constraint_info,
@@ -791,7 +792,7 @@ def get_gene_data(db, gene_id, gene,request_type, cache_key):
             result = jsonify(
                 gene=gene,
                 transcript=transcript,
-                variants_in_gene=variants_in_gene,
+                variants_in_transcript=variants_in_transcript,
                 transcripts_in_gene=transcripts_in_gene,
                 coverage_stats=coverage_stats,
                 constraint=constraint_info,

--- a/templates/gene.html
+++ b/templates/gene.html
@@ -4,8 +4,8 @@
     <script type="text/javascript">
         window.gene = {{ gene|tojson|safe }};
         window.transcript = {{ transcript|tojson|safe }};
-        window.variants_in_gene = {{ variants_in_gene|tojson|safe }};
-	window.variants_in_transcript = window.variants_in_gene;
+	window.variants_in_transcript = {{ variants_in_transcript|tojson|safe }};
+        window.variants_in_gene = window.variants_in_transcript;
         window.transcripts_in_gene = {{ transcripts_in_gene|tojson|safe }};
         window.coverage_stats = {{ coverage_stats|tojson|safe }};
         window.page_name = window.gene.gene_id;
@@ -73,7 +73,7 @@
                         <dd>{{ gene.full_gene_name }}</dd>
                     {% endif %}
                     <dt>Number of variants</dt>
-                    <dd><span id="number_of_variants"></span> (Including filtered: {{ variants_in_gene|length }})</dd>
+                    <dd><span id="number_of_variants"></span> (Including filtered: {{ variants_in_transcript|length }})</dd>
 		    <!-- <dt>Number of CNVs</dt>
 		    {% if constraint %}
 		       {% if constraint.n_cnv >= 0 %}
@@ -260,10 +260,10 @@
                     {% endwith %}
                 </div>
                 <div class="row">
-                    {% if variants_in_gene %}
-                        {% set chrom = variants_in_gene[0].chrom %}
+                    {% if variants_in_transcript %}
+                        {% set chrom = variants_in_transcript[0].chrom %}
                         {% include 'variant_table.html' %}
-                    {% else %}
+                    {% elif gene.chrom == "X" %}
                         X and Y chromosome variant data not yet available in the browser. Please subscribe to <a href="https://groups.google.com/forum/#!forum/exac_data_announcements">our mailing list</a>
                         to be notified when ExAC v2 and gnomAD VCFs are released.
                     {% endif %}

--- a/templates/gene.html
+++ b/templates/gene.html
@@ -5,12 +5,10 @@
         window.gene = {{ gene|tojson|safe }};
         window.transcript = {{ transcript|tojson|safe }};
         window.variants_in_gene = {{ variants_in_gene|tojson|safe }};
-        window.variants_in_transcript = {{ variants_in_transcript|tojson|safe }};
+	window.variants_in_transcript = window.variants_in_gene;
         window.transcripts_in_gene = {{ transcripts_in_gene|tojson|safe }};
         window.coverage_stats = {{ coverage_stats|tojson|safe }};
         window.page_name = window.gene.gene_id;
-        window.cnvs = {{ cnvs|tojson|safe }};
-        window.cnvgenes = {{ cnvgenes|tojson|safe }};
         window.uuid_lists = {{ uuid_lists|tojson|safe }};
 
         // For testing only
@@ -97,31 +95,6 @@
                             return d.filter == 'PASS' && d.category == 'lof_variant';
                         });
                         $('#number_of_lof_variants').replaceWith(lof_filtered_variants.length);
-
-			var v = window.cnvgenes;
-                        filtered_cnvs = v[0].cnv60;
-                        $('#number_of_cnvs').replaceWith(filtered_cnvs);
-
-                        unfiltered_cnvs = v[0].cnv0;
-                        $('#number_all_cnvs').replaceWith(unfiltered_cnvs);
-
-                        filtered_dels = v[0].del60;
-                        $('#number_of_dels').replaceWith(filtered_dels);
-
-                        unfiltered_dels = v[0].del0;
-                        $('#number_all_dels').replaceWith(unfiltered_dels);
-
-                        filtered_dups = v[0].dup60;
-                        $('#number_of_dups').replaceWith(filtered_dups);
-
-                        unfiltered_dups = v[0].dup0;
-                        $('#number_all_dups').replaceWith(unfiltered_dups);
-
-                        cnv_score = v[0].cnv_score;
-                        $('#cnv_score').replaceWith(cnv_score);
-
-                        rank = v[0].rank;
-                        $('#rank').replaceWith(rank);
 
                     </script>
 {#                    <dt>LoF rate</dt>#}
@@ -287,8 +260,8 @@
                     {% endwith %}
                 </div>
                 <div class="row">
-                    {% if variants_in_transcript %}
-                        {% set chrom = variants_in_transcript[0].chrom %}
+                    {% if variants_in_gene %}
+                        {% set chrom = variants_in_gene[0].chrom %}
                         {% include 'variant_table.html' %}
                     {% else %}
                         X and Y chromosome variant data not yet available in the browser. Please subscribe to <a href="https://groups.google.com/forum/#!forum/exac_data_announcements">our mailing list</a>

--- a/templates/transcript.html
+++ b/templates/transcript.html
@@ -2,16 +2,14 @@
 {% block body %}
     <!-- Render context vars in JS here -->
     <script type="text/javascript">
-        window.transcript = {{ transcript_json|safe }};
-        window.variants_in_transcript = {{ variants_in_transcript_json|safe }};
+        window.transcript = {{ transcript|tojson|safe }};
+        window.variants_in_transcript = {{ variants_in_transcript|tojson|safe }};
         // console.log(window.table_variants)
         window.table_variants = gnomad.combineDataForTable(
             window.variants_in_transcript
         )
-        window.coverage_stats = {{ coverage_stats_json|safe }};
-        window.gene = {{ gene_json|safe }};
-	    window.cnvs = {{ cnvs|tojson|safe }};
-        window.cnvgenes = {{ cnvgenes|tojson|safe }};
+        window.coverage_stats = {{ coverage_stats|tojson|safe }};
+        window.gene = {{ gene|tojson|safe }};
         $(document).ready(function() {
             $("#variant_table_annotation_header").attr("data-tooltip",
                     "Variant Effect Predictor (VEP)\n annotation using Gencode 76");


### PR DESCRIPTION
Modified mongodb queries for variants in a gene or transcript so that they only return variants in exonic regions +/- 75bp. Removed CNV-related data.