### PR TITLE
Fix parsing of multi-allelic variants for the AC_MALE and AC_FEMALE f…

### DIFF
--- a/parsing.py
+++ b/parsing.py
@@ -160,8 +160,10 @@ def get_variants_from_sites_vcf(sites_vcf):
                 variant['pop_ans'] = dict([(POPS[x], int(info_field.get('AN_%s' % x, 0))) for x in POPS])
                 variant['pop_homs'] = dict([(POPS[x], int(info_field['Hom_%s' % x].split(',')[i] if ('Hom_%s' % x) in info_field else 0)) for x in POPS])
                 if variant['chrom'] not in ('X', 'Y'):
-                    variant['ac_male'] = int(info_field['AC_Male'])
-                    variant['ac_female'] = int(info_field['AC_Female'])
+                    if not info_field['AC_Male'].split(',')[i] == ".": 
+                        variant['ac_male'] = int(info_field['AC_Male'].split(',')[i])
+                    if not info_field['AC_Female'].split(',')[i] == ".":
+                        variant['ac_female'] = int(info_field['AC_Female'].split(',')[i])
                     variant['an_male'] = int(info_field['AN_Male'])
                     variant['an_female'] = int(info_field['AN_Female'])
                 variant['hom_count'] = sum(variant['pop_homs'].values())


### PR DESCRIPTION
…ields

Prior to the change in this PR, using the gnomad downloaded data to install locally, I get errors during loading with `python manage.py load_db`  for the `AC_MALE` and `AC_FEMALE` fields for multi-allelic variants as the conversion of a comma delimited string to an `int` fails.

At first glance this PR corrects this, although I am still in process of validating the overall loading process on my end.