### PR TITLE
New import format of flask

### DIFF
--- a/exac.py
+++ b/exac.py
@@ -17,9 +17,14 @@ import warnings
 from flask.exthook import ExtDeprecationWarning
 warnings.simplefilter('ignore', ExtDeprecationWarning)
 
+#from flask import Flask, request, session, g, redirect, url_for, abort, render_template, flash, jsonify, send_from_directory
+#from flask_compress import Compress
+#from flask_runner import Runner
+
 from flask import Flask, request, session, g, redirect, url_for, abort, render_template, flash, jsonify, send_from_directory
 from flask_compress import Compress
 from flask_runner import Runner
+
 from flask_errormail import mail_on_500
 from flask_cors import CORS, cross_origin
 

--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-from flask.ext.script import Manager
+from flask_script import Manager
 from exac import app
 import exac
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "manage.py", line 1, in <module>
    from flask.ext.script import Manager
ImportError: No module named ext.script