### PR TITLE
Correct file size for gnomad.genomes.r2.0.2.sites.coding_only.chrX.vcf.bgz

### DIFF
--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -591,7 +591,7 @@ gsutil -m cp -r gs://gnomad-public/release/2.0.2/vcf/genomes/gnomad.genomes.r2.0
                             <tr>
                                 <td width="428">
                                     <p>
-                                        <a href="https://storage.googleapis.com/gnomad-public/release/2.0.2/vcf/genomes/gnomad.genomes.r2.0.2.sites.coding_only.chrX.vcf.bgz" >chr X sites VCF (coding only, 0.6 GB)</a> <a href="https://storage.googleapis.com/gnomad-public/release/2.0.2/vcf/genomes/gnomad.genomes.r2.0.2.sites.coding_only.chrX.vcf.bgz.tbi" >(.tbi)</a>
+                                        <a href="https://storage.googleapis.com/gnomad-public/release/2.0.2/vcf/genomes/gnomad.genomes.r2.0.2.sites.coding_only.chrX.vcf.bgz" >chr X sites VCF (coding only, 0.06 GB)</a> <a href="https://storage.googleapis.com/gnomad-public/release/2.0.2/vcf/genomes/gnomad.genomes.r2.0.2.sites.coding_only.chrX.vcf.bgz.tbi" >(.tbi)</a>
                                     </p>
                                 </td>
                                 <td width="428">


### PR DESCRIPTION
Fixes #83.

```
$ gsutil du -h gs://gnomad-public/release/2.0.2/vcf/genomes/gnomad.genomes.r2.0.2.sites.coding_only.chrX.vcf.bgz
68.48 MiB   gs://gnomad-public/release/2.0.2/vcf/genomes/gnomad.genomes.r2.0.2.sites.coding_only.chrX.vcf.bgz
```