### PR TITLE
Document building gnomad.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ gene_cache/
 exac_env/
 *npm-debug.log
 exac_env
-*dist
 *node_modules
 *public
 *gnomad.js

--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ Now clone the repo:
 
 ### Dependencies
 
-Follow these instructions to get Python and Homebrew installed on your Mac:
-http://docs.python-guide.org/en/latest/starting/install/osx/
+These instructions assume you are using macOS and either
+[Homebrew](https://brew.sh) or [MacPorts](https://www.macports.org)
+for package management.
+
+#### Mongo
 
 Install MongoDB:
 
@@ -49,6 +52,11 @@ This local server needs to be running at all times when you are working on the s
 You could do this in the background if you want or set up some startup service,
 but I think it's easier just to open a tab you can monitor.
 
+#### Python
+
+Follow these instructions to get Python installed on your Mac:
+http://docs.python-guide.org/en/latest/starting/install/osx/
+
 Finally, you may want to keep the system in a virtualenv:
 
     sudo port install py27-virtualenv # Or whatever version
@@ -59,6 +67,13 @@ If so, you can create a python virtual environment where the browser will live:
     virtualenv exac_env
     source exac_env/bin/activate
 
+#### Node.js
+
+Follow these instructions to install Node.js with a package manager: https://nodejs.org/en/download/package-manager/
+
+Or download and install it directly from:
+https://nodejs.org/en/download/
+
 ### Installation
 
 Install the python requirements:
@@ -66,6 +81,12 @@ Install the python requirements:
     pip install -r requirements.txt
 
 Note that this installs xBrowse too. Some packages will require Python headers (python-dev on some systems).
+
+Install JavaScript dependencies and build gnomad.js:
+
+    cd gnomad_browser/gnomad
+    npm install
+    npm run build
 
 ### Setup
 

--- a/gnomad/package.json
+++ b/gnomad/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "webpack --config webpack.config.build.js -d",
+    "build": "webpack --config webpack.config.build.js -p",
     "test": "node_modules/.bin/mocha",
     "test:watch": "node_modules/.bin/mocha --watch",
     "start": "../exac_env/bin/python ../exac.py --port 5006"

--- a/gnomad/package.json
+++ b/gnomad/package.json
@@ -4,8 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build:webpack": "webpack -d",
-    "build": "webpack --config webpack.config.build.js -d && cp ./dist/bundle.js ../static/gnomad.js",
+    "build": "webpack --config webpack.config.build.js -d",
     "test": "node_modules/.bin/mocha",
     "test:watch": "node_modules/.bin/mocha --watch",
     "start": "../exac_env/bin/python ../exac.py --port 5006"

--- a/gnomad/webpack.config.build.js
+++ b/gnomad/webpack.config.build.js
@@ -14,9 +14,9 @@ var config = {
     }]
   },
   output: {
-    path: __dirname + '/dist',
-    publicPath: 'http://localhost:8000/dist/',
-    filename: 'bundle.js',
+    path: path.resolve(__dirname, '../static'),
+    publicPath: '/',
+    filename: 'gnomad.js',
     library: 'gnomad'
   },
   resolve: {


### PR DESCRIPTION
Resolves #58.

* Document Node.js dependency and steps for building `gnomad.js`
* Minify `gnomad.js`
* Configure webpack to output `gnomad.js` directly to static folder instead of moving it in NPM script
