### PR TITLE
Return process list from load_db functions

### DIFF
--- a/exac.py
+++ b/exac.py
@@ -264,17 +264,17 @@ def load_variants(sites_vcfs, collection_name):
     if len(sites_vcfs) == 0:
         raise IOError("No vcf file found")
     elif len(sites_vcfs) == 1:
-        load_variants_single_vcf(sites_vcfs, collection_name)
+        return load_variants_single_vcf(sites_vcfs, collection_name)
     else:
-        load_variants_chunks(sites_vcfs, collection_name)
+        return load_variants_chunks(sites_vcfs, collection_name)
 
 def load_exome_variants():
     exomes_sites_vcfs = app.config['EXOMES_SITES_VCFS']
-    load_variants(exomes_sites_vcfs, 'exome_variants')
+    return load_variants(exomes_sites_vcfs, 'exome_variants')
 
 def load_genome_variants():
     genomes_sites_vcfs = app.config['GENOMES_SITES_VCFS']
-    load_variants(genomes_sites_vcfs, 'genome_variants')
+    return load_variants(genomes_sites_vcfs, 'genome_variants')
 
 def drop_exome_variants():
     db = get_db()


### PR DESCRIPTION
Related to #118.

`load_db` expects all the functions that it calls to return a list of processes.

https://github.com/macarthur-lab/gnomad_browser/blob/453a7e4b0162abadb5877806d0f4aae4383a2496/exac.py#L502-L505

When those functions do not return anything, `TypeError: 'NoneType' object is not iterable` is thrown when attempting to extend the `all_procs` list.