### PR TITLE
Hide homozygotes column for variants in y chromosome

### DIFF
--- a/templates/variant.html
+++ b/templates/variant.html
@@ -644,7 +644,9 @@
                                             {% endif %}
                                             <td id="table-count-{{ pop.replace(' ', '').replace('(', '').replace(')', '') }}"></td>
                                             <td id="table-number-{{ pop.replace(' ', '').replace('(', '').replace(')', '') }}"></td>
-                                            <td id="table-homozygotes-{{ pop.replace(' ', '').replace('(', '').replace(')', '') }}"></td>
+                                            {% if chrom != 'Y' %}
+                                                <td id="table-homozygotes-{{ pop.replace(' ', '').replace('(', '').replace(')', '') }}"></td>
+                                            {% endif %}
                                             {% if chrom == 'X' or chrom == 'Y' %}
                                                 <td id="table-hemizygotes-{{ pop.replace(' ', '').replace('(', '').replace(')', '') }}"></td>
                                             {% endif %}


### PR DESCRIPTION
Resolves #41.

Currently, in the population frequency table on the variant page, the "Number of Homozygotes" column header and sum are hidden for variants on the y chromosome. However, the column is still shown for each population, causing the "Number of Hemizygotes" and "Allele Frequency" headings to be aligned with the wrong column.

<img width="514" alt="screen shot 2018-05-11 at 4 58 17 pm" src="https://user-images.githubusercontent.com/1156625/39946568-ab5beccc-553c-11e8-8e69-6ebe0002ecd9.png">

https://github.com/macarthur-lab/gnomad_browser/blob/453a7e4b0162abadb5877806d0f4aae4383a2496/templates/variant.html#L622-L669