### PR TITLE
Display annotations for variants found only in genome dataset

### DIFF
--- a/exac.py
+++ b/exac.py
@@ -786,7 +786,7 @@ def variant_page(variant_str):
             exac_base_coverage=exac['base_coverage'],
             gnomad_base_coverage=gnomad['base_coverage'],
 
-            consequences=exac['consequences'], # TODO clean these up
+            consequences=(exac['consequences'] if 'variant_id' in exac['variant'] else gnomad['consequences']), # TODO clean these up
             exac_consequences=exac['consequences'],
             gnomad_consequences=gnomad['consequences'],
 


### PR DESCRIPTION
Currently, the variant page displays annotations based on the `consequences` field of the exome variant data.

https://github.com/macarthur-lab/gnomad_browser/blob/a3014ed0a15e5d325ea6b67a69704fcfd15e524d/templates/variant.html#L584-L607

https://github.com/macarthur-lab/gnomad_browser/blob/a3014ed0a15e5d325ea6b67a69704fcfd15e524d/exac.py#L772-L789


However, if the variant is not present in the exome dataset, then its `consequences` field will always be empty.

https://github.com/macarthur-lab/gnomad_browser/blob/a3014ed0a15e5d325ea6b67a69704fcfd15e524d/exac.py#L674-L697


Thus, if a variant appears only in the genome dataset, the variant page will not display annotations for the variant.


Resolves #116.

